### PR TITLE
Add instanced particle volume with curl turbulence

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,27 +21,8 @@
   </head>
 
   <body>
-    <!-- three.js (WebGL 2 build) -->
-    <script
-      src="https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.min.js"
-      defer
-    ></script>
-
-    <!-- lil-gui for quick controls -->
-    <script
-      src="https://cdn.jsdelivr.net/npm/lil-gui@0.19/+esm"
-      type="module"
-      defer
-    ></script>
-
-    <!-- simplex-noise (ESM) -->
-    <script
-      src="https://unpkg.com/simplex-noise@4.0.1/dist/esm/simplex-noise.js"
-      type="module"
-      defer
-    ></script>
-
-    <!-- your app -->
+    <div id="gui"></div>
+    <!-- application entry -->
     <script type="module" src="./src/main.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restructure files under `src`
- implement WebGL2 renderer and particle system driven by curl noise
- add GUI controls for instance count, size, noise scale, speed, and boundary strength
- color particles based on distance from center with subtle random variation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687576dabcb48331b6a7e76f30fb7edd