### PR TITLE
Fix simplex-noise import path

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@
 
 import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.161.0/+esm";
 import GUI from "https://cdn.jsdelivr.net/npm/lil-gui@0.19/+esm";
-import SimplexNoise from "https://unpkg.com/simplex-noise@4.0.1/dist/esm/simplex-noise.js";
+import SimplexNoise from "https://cdn.jsdelivr.net/npm/simplex-noise@4.0.1/+esm";
 
 /* ---------- CONSTANTS ---------- */
 const RADIUS = 50; // sphere volume radius (diameter 100)


### PR DESCRIPTION
## Summary
- fix incorrect SimplexNoise import to use jsDelivr ESM build

## Testing
- `npm ls simplex-noise` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6875835d6c388331bc44c2712332cf49