### PR TITLE
Add glow effect and on-screen statistics

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,11 +17,21 @@
         right: 0.5rem;
         z-index: 10;
       }
+      #info {
+        position: absolute;
+        left: 0.5rem;
+        bottom: 0.5rem;
+        color: #0f0;
+        font-family: monospace;
+        pointer-events: none;
+        z-index: 10;
+      }
     </style>
   </head>
 
   <body>
     <div id="gui"></div>
+    <div id="info"></div>
     <!-- application entry -->
     <script type="module" src="./src/main.js" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- add new `info` overlay element
- show instance count, total triangles and first instance coordinates
- add additive blending for glow effect
- update info during animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687588f71e2c8331817bc8553e5f3b56